### PR TITLE
Fix typo in README and add description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # LogisticsShippingRates
-exsam
+
+exam
+
+A simple calculator for logistics shipping rates.


### PR DESCRIPTION
Fixed typo from 'exsam' to 'exam' and added project description to improve README clarity.